### PR TITLE
chore: Fix word spelling errors

### DIFF
--- a/build_img.sh
+++ b/build_img.sh
@@ -19,7 +19,7 @@ display_help()
 	echo "  -a | --arch		architecture: x86_64|riscv64|aarch64", default is x86_64
 	echo "  -fs | --filesystem	filesystem: ext4|fat32", default is fat32
 	echo "  -file | --testcase  If not specified, use the default testcases for different architectures."
-	echi "  -s | --size		size of the disk image in 4MB batch size, default is set to 30, which means 120MB disk image"
+	echo "  -s | --size		size of the disk image in 4MB batch size, default is set to 30, which means 120MB disk image"
 	echo "  default testcases:"
 	echo "    x86_64: x86_64_linux_musl"
 	echo "    riscv64: riscv64_linux_musl"


### PR DESCRIPTION
`build_img.sh`文件中的单词拼写错误，做了调整

我写了一篇详细的适合新手的从零开始操作的文章，按照这个教程一步一步的操作就会避开各种潜在的问题了。

链接地址：[https://echoli.cn/os/new-starry-os.html](https://echoli.cn/os/new-starry-os.html)

Reviewed-by: 李扬 <echo_ai@foxmail.com>